### PR TITLE
Fix deprecated calls in all formulas

### DIFF
--- a/Formula/cddlib.rb
+++ b/Formula/cddlib.rb
@@ -8,9 +8,8 @@ class Cddlib < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/cddlib-0.94m"
-    cellar :any
-    sha256 "23e6f0cb4a6f47b6fdb3f739f2b8f8afb5f2a1fdfc3ef223023d4a1fbeab8041" => :catalina
-    sha256 "14882fd55833e9f3c836d465bfa943b219311c985fd15de6714de42f8e55ac70" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "23e6f0cb4a6f47b6fdb3f739f2b8f8afb5f2a1fdfc3ef223023d4a1fbeab8041"
+    sha256 cellar: :any, x86_64_linux: "14882fd55833e9f3c836d465bfa943b219311c985fd15de6714de42f8e55ac70"
   end
 
   unless OS.mac?

--- a/Formula/cohomcalg.rb
+++ b/Formula/cohomcalg.rb
@@ -7,9 +7,8 @@ class Cohomcalg < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/cohomcalg-0.32"
-    cellar :any_skip_relocation
-    sha256 "e78b6986b83f2b03c6c287aa94a77a374236238292cd81ad20cb1363fe48903d" => :catalina
-    sha256 "9beeba1639ebbc8201c2aeb18ebca2202b8137502be52b5b6456264be7e2f1bc" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "e78b6986b83f2b03c6c287aa94a77a374236238292cd81ad20cb1363fe48903d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "9beeba1639ebbc8201c2aeb18ebca2202b8137502be52b5b6456264be7e2f1bc"
   end
 
   def install

--- a/Formula/csdp.rb
+++ b/Formula/csdp.rb
@@ -8,9 +8,8 @@ class Csdp < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/csdp-6.2.0_6"
-    cellar :any_skip_relocation
-    sha256 "868f599e50a082a200e2c579d79f1b0ae6b80e8e6aabbf7342b1cf18a596854a" => :catalina
-    sha256 "3789c269d834322d38f3b2609107f4ae790d27caa3ffc48878210c6b311aba6d" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "868f599e50a082a200e2c579d79f1b0ae6b80e8e6aabbf7342b1cf18a596854a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "3789c269d834322d38f3b2609107f4ae790d27caa3ffc48878210c6b311aba6d"
   end
 
   depends_on "libomp" if OS.mac?

--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -7,8 +7,8 @@ class Factory < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/factory-4.2.0"
-    sha256 "ef19f68a32de51f7851f7c5110ec774756ea7912dacfc352f02478c91b70306c" => :catalina
-    sha256 "e2a7db1ab40bc0f2ca9a2e30e9317fdeddd5db4b6ac317e4c1daf983f4c806cd" => :x86_64_linux
+    sha256 catalina:     "ef19f68a32de51f7851f7c5110ec774756ea7912dacfc352f02478c91b70306c"
+    sha256 x86_64_linux: "e2a7db1ab40bc0f2ca9a2e30e9317fdeddd5db4b6ac317e4c1daf983f4c806cd"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/fflas-ffpack.rb
+++ b/Formula/fflas-ffpack.rb
@@ -8,9 +8,8 @@ class FflasFfpack < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/fflas-ffpack-2.4.3_6"
-    cellar :any_skip_relocation
-    sha256 "f8425c2b750d07259c81712aa41af644bf2ef90b0595737019e281d722a86f31" => :catalina
-    sha256 "893bc0aa938fd7e17f60b1e2c78bfa9e226936c8fa8af18d012bb8e3429af344" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "f8425c2b750d07259c81712aa41af644bf2ef90b0595737019e281d722a86f31"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "893bc0aa938fd7e17f60b1e2c78bfa9e226936c8fa8af18d012bb8e3429af344"
   end
 
   head do

--- a/Formula/fourtitwo.rb
+++ b/Formula/fourtitwo.rb
@@ -7,9 +7,8 @@ class Fourtitwo < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/fourtitwo-1.6.9"
-    cellar :any
-    sha256 "868c7c3724e64c614ccd15e61d15a4abe4bee5e7e090dfaf3dea3f29531b8ad1" => :catalina
-    sha256 "03db527ac7d43339fb40696e012859822943bf9a64113b1f8bcb1f18b0cc502d" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "868c7c3724e64c614ccd15e61d15a4abe4bee5e7e090dfaf3dea3f29531b8ad1"
+    sha256 cellar: :any, x86_64_linux: "03db527ac7d43339fb40696e012859822943bf9a64113b1f8bcb1f18b0cc502d"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/frobby.rb
+++ b/Formula/frobby.rb
@@ -7,9 +7,8 @@ class Frobby < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/frobby-0.9.5"
-    cellar :any_skip_relocation
-    sha256 "3c100ed1fb07fe444f151ea9614165b4ab28f5f9f64bb152519d20f3b0ffd664" => :catalina
-    sha256 "934bac15d4d72bee4cdf1d502f99aa4d88e9bf2ec66537029f7d76bba5070688" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "3c100ed1fb07fe444f151ea9614165b4ab28f5f9f64bb152519d20f3b0ffd664"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "934bac15d4d72bee4cdf1d502f99aa4d88e9bf2ec66537029f7d76bba5070688"
   end
 
   unless OS.mac?

--- a/Formula/gfan.rb
+++ b/Formula/gfan.rb
@@ -8,9 +8,8 @@ class Gfan < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/gfan-0.6.2_4"
-    cellar :any
-    sha256 "56436a2633e90f202bb618464d712d69483cce1489d3d73484fbfbad62daedcf" => :catalina
-    sha256 "699e49821472fbf1b5ad0c49df888754f1dee59aa19aa2c5f69f1a9d2225e172" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "56436a2633e90f202bb618464d712d69483cce1489d3d73484fbfbad62daedcf"
+    sha256 cellar: :any, x86_64_linux: "699e49821472fbf1b5ad0c49df888754f1dee59aa19aa2c5f69f1a9d2225e172"
   end
 
   if OS.mac?

--- a/Formula/givaro.rb
+++ b/Formula/givaro.rb
@@ -8,9 +8,8 @@ class Givaro < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/givaro-4.1.1_4"
-    cellar :any
-    sha256 "1ea7a960637a39ce6ed8729b2657bae825792ef03cbe5fc9667979bac70820d7" => :catalina
-    sha256 "82bbd9239d94bcc2f9f1ffad6624b43c6825ef32e6f998f62f40f558ae4e125c" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "1ea7a960637a39ce6ed8729b2657bae825792ef03cbe5fc9667979bac70820d7"
+    sha256 cellar: :any, x86_64_linux: "82bbd9239d94bcc2f9f1ffad6624b43c6825ef32e6f998f62f40f558ae4e125c"
   end
 
   head do

--- a/Formula/lrs.rb
+++ b/Formula/lrs.rb
@@ -7,9 +7,8 @@ class Lrs < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/lrs-070"
-    cellar :any
-    sha256 "f2626c93c319df8fbc8bbbfbd514fca26a50bbc3d6cf28cc622553c378e2fab8" => :catalina
-    sha256 "e64d40699b361c80c21d52085226a1fda998c67eb51684d16b65b58b2b0f7f8a" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "f2626c93c319df8fbc8bbbfbd514fca26a50bbc3d6cf28cc622553c378e2fab8"
+    sha256 cellar: :any, x86_64_linux: "e64d40699b361c80c21d52085226a1fda998c67eb51684d16b65b58b2b0f7f8a"
   end
 
   depends_on "gmp"

--- a/Formula/macaulay2.rb
+++ b/Formula/macaulay2.rb
@@ -9,8 +9,8 @@ class Macaulay2 < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/macaulay2-1.17.2_1"
-    sha256 "d667b5bff82fdbd4200f0dad1138cab1e8b1cdf188c7c0583e7ec6be60280e6c" => :catalina
-    sha256 "1c2f98cc604b2e64b1b6c34080c2d90b002a7b4ca9e9ecc70a59632ccacba645" => :x86_64_linux
+    sha256 catalina:     "d667b5bff82fdbd4200f0dad1138cab1e8b1cdf188c7c0583e7ec6be60280e6c"
+    sha256 x86_64_linux: "1c2f98cc604b2e64b1b6c34080c2d90b002a7b4ca9e9ecc70a59632ccacba645"
   end
 
   head do

--- a/Formula/mathic.rb
+++ b/Formula/mathic.rb
@@ -8,9 +8,8 @@ class Mathic < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/mathic-1.0_4"
-    cellar :any_skip_relocation
-    sha256 "6fcbcbd3b32224ba3b2cfa82590207484ad288c6fe785f9a3b855cf8ab1f9d61" => :catalina
-    sha256 "2de9c4f19a7fc5e8697d086987c6a46bad8c6bb3b66708d827ce00a829c71455" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "6fcbcbd3b32224ba3b2cfa82590207484ad288c6fe785f9a3b855cf8ab1f9d61"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "2de9c4f19a7fc5e8697d086987c6a46bad8c6bb3b66708d827ce00a829c71455"
   end
 
   unless OS.mac?

--- a/Formula/mathicgb.rb
+++ b/Formula/mathicgb.rb
@@ -8,9 +8,8 @@ class Mathicgb < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/mathicgb-1.0_6"
-    cellar :any_skip_relocation
-    sha256 "2067fb4f866250a47beafd188c68d76d29872d0125e1d2b15966531deea7c3f3" => :catalina
-    sha256 "d6b0ebd30e5abc331c8192e473eed7fa0e5c44c35cabed6362bb32b2dc191a61" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "2067fb4f866250a47beafd188c68d76d29872d0125e1d2b15966531deea7c3f3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "d6b0ebd30e5abc331c8192e473eed7fa0e5c44c35cabed6362bb32b2dc191a61"
   end
 
   option "without-mgb", "don't build mgb"

--- a/Formula/memtailor.rb
+++ b/Formula/memtailor.rb
@@ -8,9 +8,8 @@ class Memtailor < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/memtailor-1.0_8"
-    cellar :any_skip_relocation
-    sha256 "cb76875ca3ee894780fd0f0c0127f879728519c52e9825bbd08c7ab31796ef51" => :catalina
-    sha256 "8782a10b9505818b6c6944b858e3c308b1f0e4874de32d325b17780ed23674ee" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "cb76875ca3ee894780fd0f0c0127f879728519c52e9825bbd08c7ab31796ef51"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "8782a10b9505818b6c6944b858e3c308b1f0e4874de32d325b17780ed23674ee"
   end
 
   unless OS.mac?

--- a/Formula/mpsolve.rb
+++ b/Formula/mpsolve.rb
@@ -8,9 +8,8 @@ class Mpsolve < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/mpsolve-3.2.1_2"
-    cellar :any
-    sha256 "d86cca72ea66bc74bb4d78a4db2ddefabe02899b29b34e1ff06d41d26053bf7e" => :catalina
-    sha256 "1674bf7fa550bbd2c9c0b29b43c6f334d7016b79f0e37a99f2ba5a8bf9ac41e6" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "d86cca72ea66bc74bb4d78a4db2ddefabe02899b29b34e1ff06d41d26053bf7e"
+    sha256 cellar: :any, x86_64_linux: "1674bf7fa550bbd2c9c0b29b43c6f334d7016b79f0e37a99f2ba5a8bf9ac41e6"
   end
 
   unless OS.mac?

--- a/Formula/normaliz.rb
+++ b/Formula/normaliz.rb
@@ -8,9 +8,8 @@ class Normaliz < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/normaliz-3.8.9_2"
-    cellar :any
-    sha256 "807d7da3a2f145c12414135df2b17418facbe43d175425c1f4356fb2df53c2fe" => :catalina
-    sha256 "5a3bb78cdb0226407715a45d315037c2b0cfba709f86bd0f275ce8f8ecd20dfc" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "807d7da3a2f145c12414135df2b17418facbe43d175425c1f4356fb2df53c2fe"
+    sha256 cellar: :any, x86_64_linux: "5a3bb78cdb0226407715a45d315037c2b0cfba709f86bd0f275ce8f8ecd20dfc"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -9,9 +9,8 @@ class Openblas < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/openblas-0.3.13_1"
-    cellar :any
-    sha256 "a2bdb5cdf0fb13e5629d38473d61c57555debb3d6c5e88a6e4b7db0e2640de35" => :catalina
-    sha256 "5cb0cda041379272f30a43b0614b94e55f547ad8ff269daac4d7a3d787606780" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "a2bdb5cdf0fb13e5629d38473d61c57555debb3d6c5e88a6e4b7db0e2640de35"
+    sha256 cellar: :any, x86_64_linux: "5cb0cda041379272f30a43b0614b94e55f547ad8ff269daac4d7a3d787606780"
   end
 
   keg_only :shadowed_by_macos, "macOS provides BLAS in Accelerate.framework"

--- a/Formula/topcom.rb
+++ b/Formula/topcom.rb
@@ -8,9 +8,8 @@ class Topcom < Formula
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/topcom-0.17.8_2"
-    cellar :any
-    sha256 "04bb3f8321e6a3be1c1968984282244dd2b8b072784859ea09317cef7e9b505c" => :catalina
-    sha256 "8bf4db44249ae523817f236f0d78d919b6fd05c6000c7e023ee111c1c892a540" => :x86_64_linux
+    sha256 cellar: :any, catalina:     "04bb3f8321e6a3be1c1968984282244dd2b8b072784859ea09317cef7e9b505c"
+    sha256 cellar: :any, x86_64_linux: "8bf4db44249ae523817f236f0d78d919b6fd05c6000c7e023ee111c1c892a540"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Following the deprecation of calling `cellar`
and `sha256 "digest" => :tag` in a bottle block.

Fixed by running
```
brew style --fix *.rb
```