### PR TITLE
Fix missing lib from boost@1.78

### DIFF
--- a/Formula/macaulay2.rb
+++ b/Formula/macaulay2.rb
@@ -33,7 +33,7 @@ class Macaulay2 < Formula
   depends_on "pkg-config" => :build
 
   depends_on "bdw-gc"
-  depends_on "boost"
+  depends_on "boost@1.76"
   depends_on "eigen"
   depends_on "factory"
   depends_on "fflas-ffpack"


### PR DESCRIPTION
Homebrew bumped up boost to version 1.78, which leads to error
```
ninja: error: '/opt/homebrew/Cellar/boost/1.78.0/lib/libboost_stacktrace_addr2line-mt.dylib', needed by 'usr-dist/arm64-Darwin-macOS-12.2.1/bin/M2-binary', missing and no known rule to make it
```
By changing the dependency back to version boost@1.76, the compilation continues without any errors.