### PR TITLE
Fix Factory source tarball download url

### DIFF
--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -1,7 +1,7 @@
 class Factory < Formula
   desc "C++ class library for recursive representation of multivariate polynomial data"
   homepage "https://github.com/Singular/Singular/blob/spielwiese/factory/README"
-  url "https://service.mathematik.uni-kl.de/ftp/pub/Math/Factory/factory-4.2.1.tar.gz"
+  url "https://www.singular.uni-kl.de/ftp/pub/Math/Factory/factory-4.2.1.tar.gz"
   sha256 "3a3135d8d9e89bca512b22c8858f3e03f44b15629df6f0309ce4f7ddedd09a15"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
   revision 1


### PR DESCRIPTION
Change from `service.mathematik.uni-kl.de`
to `www.singular.uni-kl.de` as recommended
by Singular maintainer Hans Schoenemann.