### PR TITLE
factory: revision bump

### DIFF
--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -5,6 +5,7 @@ class Factory < Formula
   version "4.3.2p15-151235c5"
   sha256 "f1e25b566a8c06d0e98b9795741c6d12b5a34c5c0c61c078d9346d8bbc82f09f"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
+  revision 1
 
   bottle do
     root_url "https://github.com/Macaulay2/homebrew-tap/releases/download/factory-4.3.2p15-151235c5"


### PR DESCRIPTION
Build against FLINT 3.1.0 (I think this is why the `autotools-macos` builds are failing in the main `M2` repository...)


