### PR TITLE
Bump factory 4.4.1 revision to 1 (rebuild against ntl 11.6.0)

### DIFF
--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -4,7 +4,7 @@ class Factory < Formula
   url "https://macaulay2.com/Downloads/OtherSourceCode/factory-4.4.1.tar.gz"
   sha256 "345ec8ab2481135d18244e2a2ff6bc16e812a39a9eb5ac5d578956d8e0526e6e"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"


### PR DESCRIPTION
This hopefully will fix the failing macOS builds in the M2 repo (e.g., https://github.com/Macaulay2/M2/actions/runs/19187383192)