### PR TITLE
Bump M2 1.25.06 revision to 5 (rebuild against python 3.14 & ntl 11.6.0)

### DIFF
--- a/Formula/macaulay2.rb
+++ b/Formula/macaulay2.rb
@@ -5,7 +5,7 @@ class Macaulay2 < Formula
   url "https://github.com/Macaulay2/M2/archive/refs/tags/release-1.25.06.tar.gz"
   sha256 "d5cef0196ac98cd31259cfc210c6804c390ab25f081a1d116c14a1932c2e0b4a"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
-  revision 4
+  revision 5
 
   head "https://github.com/Macaulay2/M2/archive/refs/heads/development.tar.gz"
 


### PR DESCRIPTION
Also specify "eigen@3" build dependency since cmake doesn't detect eigen 5.0 yet.