### PR TITLE
Bump revisions for M2 dependencies to build tahoe bottles

### DIFF
--- a/Formula/cohomcalg.rb
+++ b/Formula/cohomcalg.rb
@@ -4,7 +4,7 @@ class Cohomcalg < Formula
   url "https://github.com/BenjaminJurke/cohomCalg/archive/refs/tags/v0.32.tar.gz"
   sha256 "367c52b99c0b0a4794b215181439bf54abe4998872d3ef25d793bc13c4d40e42"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"

--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -4,7 +4,7 @@ class Factory < Formula
   url "https://macaulay2.com/Downloads/OtherSourceCode/factory-4.4.1.tar.gz"
   sha256 "345ec8ab2481135d18244e2a2ff6bc16e812a39a9eb5ac5d578956d8e0526e6e"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"

--- a/Formula/fflas-ffpack.rb
+++ b/Formula/fflas-ffpack.rb
@@ -4,6 +4,7 @@ class FflasFfpack < Formula
   url "https://github.com/linbox-team/fflas-ffpack/releases/download/v2.5.0/fflas-ffpack-2.5.0.tar.gz"
   sha256 "dafb4c0835824d28e4f823748579be6e4c8889c9570c6ce9cce1e186c3ebbb23"
   license "LGPL-2.1-or-later"
+  revision 1
 
   head "https://github.com/linbox-team/fflas-ffpack.git", using: :git
 

--- a/Formula/frobby.rb
+++ b/Formula/frobby.rb
@@ -4,7 +4,7 @@ class Frobby < Formula
   url "https://github.com/Macaulay2/frobby.git", using: :git, branch: "master"
   version "0.9.5"
   license "GPL-2.0-only"
-  revision 4
+  revision 5
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"

--- a/Formula/givaro.rb
+++ b/Formula/givaro.rb
@@ -4,6 +4,7 @@ class Givaro < Formula
   url "https://github.com/linbox-team/givaro/releases/download/v4.2.1/givaro-4.2.1.tar.gz"
   sha256 "feefb7445842ceb756f8bb13900d975b530551e488a2ae174bda7b636251de43"
   license "CECILL-B"
+  revision 1
 
   head "https://github.com/linbox-team/givaro.git", using: :git
 


### PR DESCRIPTION
There's probably a better way to build and upload the bottles for just one architecture, but I couldn't figure it out...