### PR TITLE
Rebuild factory against flint 3.5.0

### DIFF
--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -4,7 +4,7 @@ class Factory < Formula
   url "https://macaulay2.com/Downloads/OtherSourceCode/factory-4.4.1.tar.gz"
   sha256 "345ec8ab2481135d18244e2a2ff6bc16e812a39a9eb5ac5d578956d8e0526e6e"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
-  revision 4
+  revision 5
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"

--- a/Formula/factory.rb
+++ b/Formula/factory.rb
@@ -22,6 +22,7 @@ class Factory < Formula
 
   depends_on "flint"
   depends_on "gmp"
+  depends_on "mpfr"
   depends_on "ntl"
 
   patch :DATA

--- a/Formula/macaulay2.rb
+++ b/Formula/macaulay2.rb
@@ -6,7 +6,7 @@ class Macaulay2 < Formula
   url "https://github.com/Macaulay2/M2/archive/refs/tags/release-1.25.11.tar.gz"
   sha256 "9700005196e4368af52156efaff081a4771fd21545a3cd8c2ee3b0571aeaa17f"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
-  revision 3
+  revision 4
 
   head "https://github.com/Macaulay2/M2/archive/refs/heads/development.tar.gz"
 

--- a/Formula/normaliz.rb
+++ b/Formula/normaliz.rb
@@ -4,6 +4,7 @@ class Normaliz < Formula
   url "https://github.com/Normaliz/Normaliz/releases/download/v3.11.1/normaliz-3.11.1.tar.gz"
   sha256 "9a00d590f0fdcad847e2189696d2842d97ed896ed36c22421874a364047f76e8"
   license "GPL-3.0-only"
+  revision 1
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"


### PR DESCRIPTION
FLINT 3.5.0 was just released today and it's already bottled for Homebrew Core.  But now the macOS builds in the M2 repository are failing (e.g., https://github.com/Macaulay2/M2/actions/runs/24908791594) since factory can't find FLINT 3.4.0.