### PR TITLE
Bump normaliz revision

### DIFF
--- a/Formula/normaliz.rb
+++ b/Formula/normaliz.rb
@@ -4,7 +4,7 @@ class Normaliz < Formula
   url "https://github.com/Normaliz/Normaliz/releases/download/v3.11.1/normaliz-3.11.1.tar.gz"
   sha256 "9a00d590f0fdcad847e2189696d2842d97ed896ed36c22421874a364047f76e8"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://ghcr.io/v2/macaulay2/tap"


### PR DESCRIPTION
It was rebuilt against 3.6.0 in the earlier flint transition PR (#347), but only because we changed the `formula_opt_*` syntax to fix a brew error.  We add a revision bump so that users who upgrade will get it without having to manually reinstall it.