### PR TITLE
Build x86_64 Sequoia bottles that brew test-bot skips

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -269,11 +269,9 @@ jobs:
 
   upload:
     permissions:
-      contents: read
-      issues: write # for Homebrew/actions/post-comment
-      pull-requests: write # for `gh pr edit`
-      attestations: write # for actions/attest
-      id-token: write # for actions/attest
+      contents: write # for Homebrew/actions/git-try-push
+      packages: write # for brew pr-upload
+      pull-requests: write # for Homebrew/actions/create-pull-request
     runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
@@ -307,16 +305,6 @@ jobs:
         with:
           username: ${{ (github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot' }}
 
-      - name: Set up commit signing
-        uses: Homebrew/actions/setup-commit-signing@main
-        with:
-          signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
-
-      - name: Generate build provenance
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
-
       - name: Checkout branch for bottle commit
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: git checkout -b "$BOTTLE_BRANCH" origin/HEAD
@@ -324,96 +312,54 @@ jobs:
       - name: Upload bottles to GitHub Packages
         id: upload
         env:
-          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_CORE_PATH: ${{steps.set-up-homebrew.outputs.repository-path}}
         working-directory: ${{ env.BOTTLES_DIR }}
         run: |
-          brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/macaulay2/tap"
+          brew pr-upload --verbose --keep-old --root-url="https://ghcr.io/v2/macaulay2/tap"
           echo "title=$(git -C "$HOMEBREW_CORE_PATH" log -1 --format='%s' "$BOTTLE_BRANCH")" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(git -C "$HOMEBREW_CORE_PATH" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@main
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{ github.token }}
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           branch: ${{env.BOTTLE_BRANCH}}
-        env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
 
+      # Opening a PR with GITHUB_TOKEN needs the organisation's "Allow GitHub
+      # Actions to create and approve pull requests" setting, which is off by
+      # default and needs an org admin.  The branch has already been pushed by
+      # this point, so if PR creation is refused just carry on -- the summary
+      # below links straight to the compare view.
       - name: Open PR with bottle commit
         id: create-pr
+        continue-on-error: true
         uses: Homebrew/actions/create-pull-request@main
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{ github.token }}
           base: ${{github.ref}}
           head: ${{env.BOTTLE_BRANCH}}
           title: ${{steps.upload.outputs.title}}
           body: Created by [`brew dispatch-build-bottle`](${{env.RUN_URL}})
-          labels: CI-published-bottle-commits
           reviewers: ${{github.actor}}
 
-      - name: Enable automerge
-        env:
-          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          NODE_ID: ${{steps.create-pr.outputs.node_id}}
-          SHA: ${{steps.upload.outputs.head_sha}}
-          MUTATION: |-
-            mutation ($input: EnablePullRequestAutoMergeInput!) {
-              enablePullRequestAutoMerge(input: $input) {
-                clientMutationId
-              }
-            }
+      - name: Summarise
+        if: always()
         run: |
-          gh api graphql \
-            --field "input[pullRequestId]=$NODE_ID" \
-            --field "input[expectedHeadOid]=$SHA" \
-            --raw-field query="$MUTATION"
-
-      - name: Approve PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{steps.create-pr.outputs.number}}
-        run: |
-          gh api \
-            --method POST \
-            --header "Accept: application/vnd.github+json" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
-            --field "event=APPROVE"
-
-      - name: Wait until PR is merged
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.create-pr.outputs.number }}
-        run: |
-          # Hold the `concurrency` lock for up to another 10 minutes while the PR has not yet been merged.
-          sleep 300
-
-          attempt=0
-          max_attempts=5
-          sleep_time=10
-
-          while (( attempt < max_attempts ))
-          do
-            if jq --exit-status .merged_at
-            then
-              break
-            fi < <( # We could use `gh pr view`, but that uses 2 API calls.
-              gh api \
-                --header "Accept: application/vnd.github+json" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "/repos/$GITHUB_REPOSITORY/pulls/$PR"
-            )
-
-            sleep "$sleep_time"
-
-            sleep_time=$(( sleep_time * 2 ))
-            attempt=$(( attempt + 1 ))
-          done
+          {
+            echo "### Bottle for \`${DISPATCH_BUILD_BOTTLE_FORMULA}\` on \`${DISPATCH_BUILD_BOTTLE_RUNNER}\`"
+            echo
+            echo "The bottle is **already on ghcr** -- \`brew pr-upload --keep-old\` pushed it"
+            echo "before this branch existed.  Merging is what makes the formula reference it."
+            echo
+            echo "- Branch: \`${BOTTLE_BRANCH}\`"
+            echo "- Review and merge: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${BOTTLE_BRANCH}?expand=1"
+            echo
+            echo "Expect exactly one added \`sha256\` line, with \`rebuild\` and the other"
+            echo "checksums untouched.  Do **not** label it \`pr-pull\`: \`publish.yml\` runs"
+            echo "\`brew pr-pull\` without \`--keep-old\` and would regenerate the whole bottle block."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   comment:
     permissions:

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -182,7 +182,9 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
-      - working-directory: ${{ env.BOTTLES_DIR }}
+      - name: Build bottle
+        if: matrix.runner != 'macos-15-intel'
+        working-directory: ${{ env.BOTTLES_DIR }}
         run: |
           brew test-bot \
             --only-formulae \
@@ -192,6 +194,57 @@ jobs:
             --skip-dependents \
             --root-url="https://ghcr.io/v2/macaulay2/tap" \
             "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+
+      # "brew test-bot" refuses to bottle a formula unless every build and
+      # runtime dependency has a bottle for *this exact* OS tag -- see
+      # build_bottle? in homebrew-test-bot's lib/tests/formulae.rb. Since
+      # homebrew-core builds its x86_64 macOS bottles on Sonoma, almost nothing
+      # has a sequoia one, so on macos-15-intel that check skips nearly every
+      # formula we have (fflas-ffpack, for instance, on account of libomp).
+      #
+      # Homebrew is happy to pour an older-OS bottle at install time, and
+      # "brew bottle" has no such restriction, so going through brew directly
+      # skips the policy check. The result is a sequoia bottle built against
+      # the same sonoma dependencies every Intel Sequoia user already has
+      # installed -- and it serves Intel Tahoe users too, via the same
+      # older-bottle fallback.
+      - name: Build bottle (deps may be bottled for an older macOS)
+        if: matrix.runner == 'macos-15-intel'
+        working-directory: ${{ env.BOTTLES_DIR }}
+        env:
+          # test-bot redirects these into the bottles directory so that
+          # post-build can upload them; without it a failed build leaves its
+          # logs in ~/Library/Logs on an ephemeral runner and we learn nothing.
+          HOMEBREW_LOGS: ${{ env.BOTTLES_DIR }}/logs
+        run: |
+          brew install --only-dependencies --include-test --formula "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+          brew install --build-bottle --verbose --formula "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+          brew bottle \
+            --json \
+            --keep-old \
+            --only-json-tab \
+            --root-url="https://ghcr.io/v2/macaulay2/tap" \
+            "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+
+          # Pour the bottle we just built and test *that*, the way test-bot
+          # does.  The --build-bottle tree still has literal /usr/local paths
+          # in it, so testing it directly would not catch relocation damage --
+          # and pouring is also what runs post_install.
+          brew bottle --merge --write --no-commit --no-all-checks --keep-old \
+            ./"${DISPATCH_BUILD_BOTTLE_FORMULA}"--*.bottle.json
+
+          # Note the tarball carries the rebuild number and the JSON tab does
+          # not, so this glob needs the extra "*": the file is called
+          # <name>--<version>.<tag>.bottle.<rebuild>.tar.gz.
+          bottle=$(ls ./"${DISPATCH_BUILD_BOTTLE_FORMULA}"--*.bottle*.tar.gz)
+
+          brew uninstall --formula --force --ignore-dependencies "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+          # "brew uninstall" autoremoves the dependencies it just orphaned, so
+          # put them back before pouring, as test-bot does.
+          brew install --only-dependencies "$bottle"
+          brew install "$bottle"
+          brew linkage --test "${DISPATCH_BUILD_BOTTLE_FORMULA}"
+          brew test --verbose "${DISPATCH_BUILD_BOTTLE_FORMULA}"
 
       - name: Post-build steps
         if: always()

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -190,6 +190,7 @@ jobs:
             --only-json-tab \
             --skip-online-checks \
             --skip-dependents \
+            --root-url="https://ghcr.io/v2/macaulay2/tap" \
             "${DISPATCH_BUILD_BOTTLE_FORMULA}"
 
       - name: Post-build steps

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -246,6 +246,18 @@ jobs:
           brew linkage --test "${DISPATCH_BUILD_BOTTLE_FORMULA}"
           brew test --verbose "${DISPATCH_BUILD_BOTTLE_FORMULA}"
 
+      # "brew test-bot" exits 0 when it skips a formula -- a green build step
+      # does not mean a bottle exists.  Fail here rather than letting the
+      # upload job run "brew pr-upload" against an empty directory.
+      - name: Check that a bottle was actually built
+        working-directory: ${{ env.BOTTLES_DIR }}
+        run: |
+          if ! compgen -G "*.bottle.json" > /dev/null
+          then
+            echo "::error ::No bottle was produced for ${DISPATCH_BUILD_BOTTLE_FORMULA} on ${DISPATCH_BUILD_BOTTLE_RUNNER}."
+            exit 1
+          fi
+
       - name: Post-build steps
         if: always()
         uses: Homebrew/actions/post-build@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,65 @@ jobs:
       - run: brew test-bot --only-formulae --verbose --root-url=https://ghcr.io/v2/macaulay2/tap
         if: github.event_name == 'pull_request'
 
+      # "brew test-bot" refuses to bottle a formula unless every build and
+      # runtime dependency has a bottle for *this exact* OS tag -- build_bottle?
+      # in homebrew-test-bot's lib/tests/formulae.rb.  homebrew-core builds its
+      # x86_64 macOS bottles on Sonoma, so on macos-15-intel most of this tap
+      # gets skipped, and test-bot exits 0 when it skips: the job goes green
+      # having built nothing.
+      #
+      # Homebrew pours an older-OS bottle happily at install time and "brew
+      # bottle" has no such restriction, so build those by hand.  test-bot
+      # records skipped and failed formulae in the same file, but this step
+      # only runs when test-bot itself succeeded, so every name here is a skip.
+      #
+      # Note there is no --keep-old: on a pull request every platform rebuilds
+      # together, so this bottle must take the same new rebuild number as the
+      # ones test-bot produced.
+      - name: Build formulae skipped for want of an x86_64 sequoia bottle
+        if: success() && matrix.os == 'macos-15-intel' && github.event_name == 'pull_request'
+        env:
+          # Installing a bottle from a path is forbidden unless this is set --
+          # see forbid_packages_from_paths? in Homebrew's env_config.rb, which
+          # defaults to true for non-developers.  The dispatch workflow sets it
+          # workflow-wide; this one does not, deliberately, so scope it here.
+          HOMEBREW_DEVELOPER: 1
+        run: |
+          # tests.yml does not set a tracing shell the way the dispatch
+          # workflow does, and this needs to be debuggable from the log.
+          set -x
+
+          skipped=$(cat skipped_or_failed_formulae-*.txt 2>/dev/null || true)
+          if [ -z "$skipped" ]
+          then
+            echo "test-bot skipped nothing; nothing to do."
+            exit 0
+          fi
+
+          for formula in ${skipped//,/ }
+          do
+            echo "::group::Building $formula"
+            short="${formula##*/}"
+
+            brew install --only-dependencies --include-test --formula "$formula"
+            brew install --build-bottle --verbose --formula "$formula"
+            brew bottle --json --root-url="https://ghcr.io/v2/macaulay2/tap" "$formula"
+
+            # Pour it and test that, as test-bot does for everything else: the
+            # --build-bottle tree still has literal /usr/local paths in it, so
+            # testing it directly would not catch relocation damage, and
+            # pouring is what runs post_install.
+            brew bottle --merge --write --no-commit --no-all-checks ./"$short"--*.bottle.json
+            # Absolute, so brew cannot mistake it for a formula name.
+            bottle=$(ls "$PWD"/"$short"--*.bottle*.tar.gz)
+            brew uninstall --formula --force --ignore-dependencies "$formula"
+            brew install --only-dependencies "$bottle"
+            brew install "$bottle"
+            brew linkage --test "$formula"
+            brew test --verbose "$formula"
+            echo "::endgroup::"
+          done
+
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,14 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
+      # Records testing_formulae, added_formulae and deleted_formulae as step
+      # outputs.  We only want the first, to tell "this pull request builds
+      # nothing" apart from "this pull request should have built something".
+      - name: Detect formulae under test
+        id: detect
+        if: github.event_name == 'pull_request'
+        run: brew test-bot --only-formulae-detect
+
       - run: brew test-bot --only-formulae --verbose --root-url=https://ghcr.io/v2/macaulay2/tap
         if: github.event_name == 'pull_request'
 
@@ -109,13 +117,31 @@ jobs:
             echo "::endgroup::"
           done
 
+      # test-bot exits 0 when it skips a formula, so a green run does not mean
+      # anything was built.  Check for ourselves -- but only when test-bot had
+      # something to build in the first place, so that a pull request touching
+      # only workflows or documentation stays green.
+      - name: Check that bottles were built
+        if: success() && github.event_name == 'pull_request' && steps.detect.outputs.testing_formulae != ''
+        env:
+          TESTING_FORMULAE: ${{ steps.detect.outputs.testing_formulae }}
+        run: |
+          if ! compgen -G "*.bottle.json" > /dev/null
+          then
+            echo "::error ::${TESTING_FORMULAE} was tested but produced no bottle."
+            exit 1
+          fi
+
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'
-          if-no-files-found: error
+          # Silent: the step above is what decides whether missing bottles are
+          # a problem, and a pull request that touches no formula legitimately
+          # builds nothing.
+          if-no-files-found: ignore
 
       - name: Upload logs as artifact
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
## Why

`brew test-bot` will not bottle a formula unless every build and runtime
dependency has a bottle for *this exact* OS tag — `build_bottle?` in
homebrew-test-bot's `lib/tests/formulae.rb`, which passes
`no_older_versions: !dep.test?`.

homebrew-core builds its x86_64 macOS bottles on Sonoma, so seventeen of the
thirty-four core formulae we depend on have no `sequoia` bottle, `libomp` and
`flint` among them. On `macos-15-intel` that check skips all but six of our
twenty-one formulae — and test-bot **exits 0 when it skips**, so those jobs go
green having built nothing.

That is how we came to publish a `sequoia` bottle for givaro but not for
fflas-ffpack: givaro's dependencies all happen to have `sequoia` bottles, and
fflas-ffpack adds `libomp`, which does not. Intel users therefore pour a
prebuilt givaro and compile fflas-ffpack against it, which is #349.

Homebrew pours an older-OS bottle happily at *install* time, and `brew bottle`
has no such restriction, so on that one runner this drives brew directly
instead. The resulting `sequoia` bottle is built against the same `sonoma`
dependencies every Intel Sequoia user already has installed, and it serves
Intel Tahoe users too through the same fallback.

## What's here

- **Pass `--root-url` to `brew test-bot`.** Without it test-bot invents one for
  a non-core tap — our releases URL rather than ghcr — and `brew bottle` treats
  a root_url mismatch as fatal under `--keep-old`. A dispatch on any arm64
  runner would have built for the best part of an hour and only then died.
  Never observed because every dispatch so far bailed out earlier.
- **Build bottles on `macos-15-intel` without test-bot's dependency check.**
  Also pours and tests the bottle rather than the `--build-bottle` tree, which
  still has literal `/usr/local` paths in it, and redirects `HOMEBREW_LOGS` so
  a failed build leaves something to read.
- **Fail loudly when no bottle gets built**, since a green test-bot step does
  not mean anything was produced.
- **Use the default token for the dispatch bottle upload.** That job has never
  run to completion: it was copied from homebrew-core along with homebrew-core's
  secret names, and this tap has no Actions secrets at all, so it died at
  "Set up commit signing". `publish.yml` already shows `GITHUB_TOKEN` is enough
  for both the ghcr upload and the push.
- **Apply the same treatment in `tests.yml`**, reading test-bot's own skip list
  so that only the formulae it declined are built by hand.
- **Only demand bottles when a formula was actually tested**, via
  `brew test-bot --only-formulae-detect`. `if-no-files-found: error` fires
  whenever no bottles exist, so a pull request touching only workflows or
  documentation turned every job red — this one included.

## Evidence

Run on https://github.com/d-torrance/homebrew-tap:

- [dispatch, `macos-15-intel`](https://github.com/d-torrance/homebrew-tap/actions/runs/31283891298) — built, bottled, poured, `brew linkage --test` and `brew test` all green
- [`tests.yml` bypass, full matrix](https://github.com/d-torrance/homebrew-tap/actions/runs/31285792232) — all six green, x86_64 bottle produced through the normal pull request flow
- [detect/check with a formula change](https://github.com/d-torrance/homebrew-tap/actions/runs/31286687068) and [without one](https://github.com/d-torrance/homebrew-tap/actions/runs/31286688320)

## Not covered

- The fork needs `--skip-dependents` to test anything at all, because
  `macaulay2.rb` says `depends_on "macaulay2/tap/factory"` and that tap is not
  installed there. This branch does **not** carry that, so the `tests.yml` path
  here has not been exercised with dependent testing enabled.
- `macos-14-large` has never been assigned a runner on this repository — eight
  consecutive runs with zero steps — so it fails before any of this executes.
  Unchanged by this PR, but it does mean every pull request carries one
  guaranteed red X, which might be worth addressing separately.
- `dispatch-rebottle.yml` has the identical missing-secrets problem and is
  equally dead. Left alone to keep this diff focused.

---

*This pull request — the workflow changes and this description — was written by
Claude Opus 5, working with @d-torrance, who directed the investigation and
reviewed the result. The commits carry `Co-Authored-By` trailers accordingly.*