### PR TITLE
fflas-ffpack: link Givaro into all precompiled libraries

### DIFF
--- a/Formula/fflas-ffpack.rb
+++ b/Formula/fflas-ffpack.rb
@@ -26,6 +26,16 @@ class FflasFfpack < Formula
   depends_on "libomp" if OS.mac?
   depends_on "openblas" unless OS.mac?
 
+  # Link Givaro and BLAS directly into all precompiled libraries.  Only
+  # libfflas listed $(GIVARO_LIBS); libffpack, libfflas_c and libffpack_c
+  # relied on reaching Givaro through it, which libtool does not propagate,
+  # so libfflas_c fails to link on macOS.  Reported upstream as
+  # linbox-team/fflas-ffpack#391.
+  patch do
+    url "https://github.com/linbox-team/fflas-ffpack/commit/9391c9422424d47d6b6d0c02a1af72fd2ee97a0f.patch?full_index=1"
+    sha256 "067339896c4e99e5b47873caca5a952d28dae3068da48f9faa72697ba17ec0d3"
+  end
+
   patch :DATA
 
   def install


### PR DESCRIPTION
Closes #349.

## The bug

On x86_64 macOS, `libfflas_c` fails to link:

```
Undefined symbols for architecture x86_64:
  "Givaro::Integer::operator%(unsigned long long) const", referenced from:
      Givaro::Modular<double, double, void>::init(double&, Givaro::Integer const&) const in fflas_lvl1.o
```

`fflas-ffpack/interfaces/libs/Makefile.am` gives Givaro to `libfflas` and to
nothing else:

```make
libfflas_la_LIBADD=    $(GIVARO_LIBS) $(BLAS_LIBS) $(PARLIBS)
libffpack_la_LIBADD=   libfflas.la
libfflas_c_la_LIBADD=  libfflas.la
libffpack_c_la_LIBADD= libffpack.la
```

The other three rely on reaching Givaro through `libfflas.la`. libtool copies a
dependency's `dependency_libs` into the `.la` record but only adds the `-L`
search paths to the actual link command — never the matching `-l` flags. On ELF
that merely underlinks them, since they resolve Givaro through `libfflas.so`'s
`DT_NEEDED`; on Mach-O, where a symbol must come from a library named directly
on the link line, it is fatal.

## Why now

Two things had to line up, which is why this is only surfacing in August:

- `--enable-precompilation` was added to our formula in d7a4393 (2026-03-03).
  These four libraries live inside `if FFLASFFPACK_PRECOMPILED` and are not
  built without it.
- Our last x86_64 macOS bottle predates that, so no build here had exercised
  the combination. arm64 and Linux build fine — Linux resolves Givaro
  transitively, and on arm64 the symbol is not emitted out of line.

Intel users started hitting it once we published a `sequoia` bottle for givaro
but could not build one for fflas-ffpack: they pour a prebuilt givaro and
compile fflas-ffpack against it locally.

## Upstream

Reported as linbox-team/fflas-ffpack#391, open since 2024-01-02. That report
stalled because it could not be reproduced from the standard install
instructions — precompilation is off by default, so a plain `./configure` never
builds the affected targets at all.

Fix submitted as linbox-team/fflas-ffpack#420, **still open**. The patch URL
here points at the pull request's head commit rather than the pull request
itself, so it is immutable and satisfies `brew audit`. Worth repointing at the
merge commit once it lands.

## Testing

Verified on https://github.com/d-torrance/homebrew-tap:

- [x86_64 Sequoia](https://github.com/d-torrance/homebrew-tap/actions/runs/31283891298) — builds, bottles, pours, `brew linkage --test` and `brew test` all pass
- [full matrix](https://github.com/d-torrance/homebrew-tap/actions/runs/31285792232) — arm64 Sonoma/Sequoia/Tahoe and Linux green, so the patch is a no-op where Givaro was already resolving transitively

All four link lines now carry `-lgivaro`, where previously only `libfflas` did.

No `revision` bump, following 1b7453c — `rebuild` covers it.

---

*This pull request and its description were written by Claude Opus 5, working
with @d-torrance, who directed the investigation and reviewed the result.*