### PR TITLE
eantic: 2.1.1, and fix the build against FLINT 3.6.0

### DIFF
--- a/Formula/eantic.rb
+++ b/Formula/eantic.rb
@@ -1,8 +1,8 @@
 class Eantic < Formula
   desc "Computing with Real Embedded Number Fields"
   homepage "https://flatsurf.github.io/e-antic/"
-  url "https://github.com/flatsurf/e-antic/releases/download/2.1.0/e-antic-2.1.0.tar.gz"
-  sha256 "e3e78701d054b441f95d83b6fb55cd84bfd931f5d4a61a2822dc977a20c46f80"
+  url "https://github.com/flatsurf/e-antic/releases/download/2.1.1/e-antic-2.1.1.tar.gz"
+  sha256 "e3287fa603b44d9a43c4cac5d883e65e90aedc35821061c1dc5b8d9c94a01cd8"
   license any_of: ["LGPL-3.0-only", "GPL-3.0-only"]
 
   bottle do
@@ -19,6 +19,15 @@ class Eantic < Formula
 
   depends_on "boost"
   depends_on "flint"
+
+  # FLINT 3.6.0 declares the real root isolation functions that e-antic also
+  # declares, so building against it fails with conflicting types.  Reported
+  # upstream as https://github.com/flatsurf/e-antic/issues/308; patch taken
+  # from Debian.
+  patch do
+    url "https://sources.debian.org/data/main/e/e-antic/2.1.1%2Bds-2/debian/patches/isolate-real-roots.patch"
+    sha256 "0ecec1fb773e9a1a39bba1751e90cd32de7ce579126439facb3263ed1709bf4d"
+  end
 
   # skipping pyeantic due to https://github.com/flatsurf/e-antic/issues/283
   patch :DATA


### PR DESCRIPTION
## The bug

e-antic does not build against FLINT 3.6.0:

```
fmpz_poly_extra/../../e-antic/fmpz_poly_extra.h:49:19: error: conflicting types for '_fmpz_poly_has_real_root'
   49 | LIBEANTIC_API int _fmpz_poly_has_real_root(fmpz * pol, slong len);
      |                   ^
/usr/local/include/flint/fmpz_poly.h:1218:5: note: previous declaration is here
 1218 | int _fmpz_poly_has_real_root(const fmpz * p, slong len);
```

FLINT has absorbed the real root isolation functions that e-antic declares, and
the two declarations differ by a `const`.

This is **not** architecture specific. Our arm64 bottles were built in November,
before the FLINT bump, and are the only thing hiding it — anyone building
e-antic from source today is already broken. It surfaced now only because a
dispatched x86_64 build had to compile it rather than pour it.

Bumping alone does not help: 2.1.1's `fmpz_poly_extra.h` is byte-identical to
2.1.0's. Its release notes mention *"Fixed (linker) issues with macOS 15"*,
which reads like this problem and is not.

Reported upstream as flatsurf/e-antic#308, still open, so this takes Debian's
patch, which drops the declarations FLINT now provides.

## Checked before submitting

- the patch applies cleanly to both 2.1.0 and 2.1.1
- 2.1.0's tarball checksum matches what the formula already pins, so the
  comparison was against the right source
- the existing `patch :DATA` for pyeantic still applies to 2.1.1, and both
  patches apply together
- the patch URL is pinned to the Debian source package version `2.1.1+ds-2`
  rather than a branch tip, so it is immutable

The stale bottle block is left for `pr-pull` to replace, following f913fbe.

---

*This pull request and its description were written by Claude Opus 5, working
with @d-torrance, who identified the bug — having fixed it in Debian — and
reviewed the result.*