### PR TITLE
fflas-ffpack: bump revision so existing installs get replaced

### DIFF
--- a/Formula/fflas-ffpack.rb
+++ b/Formula/fflas-ffpack.rb
@@ -4,6 +4,7 @@ class FflasFfpack < Formula
   url "https://github.com/linbox-team/fflas-ffpack/releases/download/v2.5.0/fflas-ffpack-2.5.0.tar.gz"
   sha256 "dafb4c0835824d28e4f823748579be6e4c8889c9570c6ce9cce1e186c3ebbb23"
   license "LGPL-2.1-or-later"
+  revision 1
 
   head "https://github.com/linbox-team/fflas-ffpack.git", using: :git, branch: "master"
 


### PR DESCRIPTION
Fixes the startup failure reported on the mailing list:

> `Library not loaded: /opt/homebrew/opt/fflas-ffpack/lib/libfflas.1.dylib`

https://groups.google.com/g/macaulay2/c/YfBaj9iiCSw

## What happened

Passing `--enable-precompilation` in d7a4393 changed what lands in the keg.
Upstream keeps all four `lib_LTLIBRARIES` inside `if FFLASFFPACK_PRECOMPILED`,
so before that commit fflas-ffpack installed **nothing but headers**. The
bottle payload tells the story:

| | bottle size |
|---|---|
| rebuild 2 — before | 360,328 bytes |
| rebuild 3 — after | 2,006,183 bytes |

That went out as a `rebuild` rather than a `revision`. `rebuild` is a bottle
attribute and is not part of the version Homebrew compares, so `brew upgrade`
saw 2.5.0 against 2.5.0, concluded there was nothing to do, and left every
existing keg untouched. Macaulay2 has been rebuilt since and links
`libfflas.1.dylib` through the `opt` path — which resolves to a keg that does
not contain it.

Nothing was wrong with `depends_on "fflas-ffpack"`. The dependency genuinely
was satisfied; Homebrew had no way to know the contents had changed.

That `brew install fflas-ffpack` does not fix it while `brew reinstall` does is
the same symptom seen from the other side: there is nothing to install, because
the version has not moved. Only `reinstall` replaces a keg at an unchanged
version.

## Why a revision

It is the mechanism for exactly this — the build output changed without an
upstream version change — so affected users pick it up on their next
`brew upgrade` rather than having to diagnose it. `revision 1` is the right
value; this formula has not carried one since 2.5.0 landed in ac1deaa
(2021-12-21).

It also delivers 20ac25a, which changed the installed libraries for the same
reason and would otherwise reach nobody either.

This is orthogonal to the x86_64 work: the mailing list reports are from arm64.

---

*This pull request and its description were written by Claude Opus 5, working
with @d-torrance, who supplied the user reports and reviewed the result.*