### PR TITLE
linbox: do not link the unused MPFR library

### DIFF
--- a/Formula/linbox.rb
+++ b/Formula/linbox.rb
@@ -48,6 +48,9 @@ class Linbox < Formula
     system "autoreconf", "-vif"
     system "./configure",
            "--enable-openmp",
+           # LinBox uses no MPFR symbols; if found, it only adds "-lmpfr" to
+           # the link, which breaks "brew linkage --test".
+           "--without-mpfr",
            "--disable-dependency-tracking",
            "--disable-silent-rules",
            "--prefix=#{prefix}"


### PR DESCRIPTION
Building an x86_64 `sequoia` bottle for `linbox` fails at the final `brew linkage --test` step ([run 31289684927](https://github.com/Macaulay2/homebrew-tap/actions/runs/31289684927/job/93184713723)):

```
Indirect dependencies with linkage:
  mpfr
```

`liblinbox.0.dylib` links `libmpfr`, but `mpfr` is not a declared dependency — it is only present transitively via `flint`. LinBox's `macros/mpfr-check.m4` searches `DEFAULT_CHECKING_PATH`, hardcoded in `macros/linbox-misc.m4` as `/usr /usr/local`. On an Intel runner that *is* the Homebrew prefix, so MPFR gets picked up where it sits as flint's dependency. On arm64 (`/opt/homebrew`) and Linux it is never found, which is why only `macos-15-intel` trips this.

It became fatal rather than cosmetic in Homebrew [c933acc6](https://github.com/Homebrew/brew/commit/c933acc6), "linkage_checker: treat indirect deps as general test failure", which moved indirect deps out of the `--strict`-only bucket.

Rather than adding `depends_on "mpfr"`, this opts out: LinBox has no MPFR support to enable. There is no `#include <mpfr.h>` anywhere in the tree, no source file guarded on `__LINBOX_HAVE_MPFR`, and the `AM_CONDITIONAL(LINBOX_HAVE_MPFR, ...)` at the end of `mpfr-check.m4` is referenced by no `Makefile.am` — the sole effect of the check succeeding is `${MPFR_LIBS}` landing in `LINBOX_DEPS_LIBS` (`configure.ac:166`) and hence in `linbox.pc`'s `Libs:`. The same is true on current upstream master. So the linkage resolves zero symbols and the flag leaks into downstream link lines for nothing.

No revision bump: `--without-mpfr` is a no-op on arm64 macOS and Linux, where MPFR was never being found, so the existing bottles remain valid. Only the Intel build changes, and it has no bottle yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)