### PR TITLE
Drop macos-14-large and bring dispatch-rebottle.yml up to date

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -343,8 +343,12 @@ jobs:
           body: Created by [`brew dispatch-build-bottle`](${{env.RUN_URL}})
           reviewers: ${{github.actor}}
 
+      # Deliberately success(), not always(): the text below asserts that the
+      # bottle reached ghcr, which is only true once "brew pr-upload" and the
+      # push have both succeeded.  A refused pull request does not skip this --
+      # that step is continue-on-error, so it leaves the job successful.
       - name: Summarise
-        if: always()
+        if: success()
         run: |
           {
             echo "### Bottle for \`${DISPATCH_BUILD_BOTTLE_FORMULA}\` on \`${DISPATCH_BUILD_BOTTLE_RUNNER}\`"

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -72,7 +72,6 @@ jobs:
           script: |
             const linuxRegex = /^(?:ubuntu-|linux-self-hosted-)/;
             const macOSRunners = {
-              "14": "macos-14-large",
               "14-arm64": "macos-14",
               "15": "macos-15-intel",
               "15-arm64": "macos-15",

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -131,9 +131,13 @@ jobs:
         with:
           bottles-directory: ${{ env.BOTTLES_DIR }}
 
+      # Without it test-bot invents a root URL for a non-core tap -- our
+      # releases URL rather than ghcr -- and the bottle JSON then disagrees
+      # with what "brew pr-upload" publishes.
       - run: |
           brew test-bot --only-formulae --only-json-tab --skip-online-checks \
                         --skip-dependents \
+                        --root-url="https://ghcr.io/v2/macaulay2/tap" \
                         "${DISPATCH_REBOTTLE_FORMULA}"
         working-directory: ${{ env.BOTTLES_DIR }}
         env:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -131,17 +131,85 @@ jobs:
         with:
           bottles-directory: ${{ env.BOTTLES_DIR }}
 
-      # Without it test-bot invents a root URL for a non-core tap -- our
-      # releases URL rather than ghcr -- and the bottle JSON then disagrees
-      # with what "brew pr-upload" publishes.
-      - run: |
+      # --root-url matters here for the same reason as in
+      # dispatch-build-bottle.yml: without it test-bot invents a root URL for a
+      # non-core tap -- our releases URL rather than ghcr -- and the bottle JSON
+      # then disagrees with what "brew pr-upload" publishes.
+      - name: Build bottle
+        if: ${{ !endsWith(matrix.runner, '-intel') }}
+        working-directory: ${{ env.BOTTLES_DIR }}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
           brew test-bot --only-formulae --only-json-tab --skip-online-checks \
                         --skip-dependents \
                         --root-url="https://ghcr.io/v2/macaulay2/tap" \
                         "${DISPATCH_REBOTTLE_FORMULA}"
+
+      # "brew test-bot" refuses to bottle a formula unless every build and
+      # runtime dependency has a bottle for *this exact* OS tag -- see
+      # build_bottle? in homebrew-test-bot's lib/tests/formulae.rb.  Since
+      # homebrew-core builds its x86_64 macOS bottles on Sonoma, almost nothing
+      # has a sequoia one, so on an Intel runner that check skips nearly every
+      # formula we have -- and test-bot exits 0 when it skips.
+      #
+      # Homebrew pours an older-OS bottle happily at install time and "brew
+      # bottle" has no such restriction, so go through brew directly.
+      #
+      # Note there is no --keep-old, matching the test-bot call above: a
+      # rebottle rebuilds every currently-bottled tag together, so this bottle
+      # must take the same new rebuild number as the ones test-bot produced.
+      - name: Build bottle (deps may be bottled for an older macOS)
+        if: endsWith(matrix.runner, '-intel')
         working-directory: ${{ env.BOTTLES_DIR }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # test-bot redirects these into the bottles directory so that
+          # post-build can upload them; without it a failed build leaves its
+          # logs in ~/Library/Logs on an ephemeral runner and we learn nothing.
+          HOMEBREW_LOGS: ${{ env.BOTTLES_DIR }}/logs
+        run: |
+          brew install --only-dependencies --include-test --formula "${DISPATCH_REBOTTLE_FORMULA}"
+          brew install --build-bottle --verbose --formula "${DISPATCH_REBOTTLE_FORMULA}"
+          brew bottle \
+            --json \
+            --only-json-tab \
+            --root-url="https://ghcr.io/v2/macaulay2/tap" \
+            "${DISPATCH_REBOTTLE_FORMULA}"
+
+          # Pour the bottle we just built and test *that*, the way test-bot
+          # does.  The --build-bottle tree still has literal /usr/local paths
+          # in it, so testing it directly would not catch relocation damage --
+          # and pouring is also what runs post_install.
+          brew bottle --merge --write --no-commit --no-all-checks \
+            ./"${DISPATCH_REBOTTLE_FORMULA}"--*.bottle.json
+
+          # Note the tarball carries the rebuild number and the JSON tab does
+          # not, so this glob needs the extra "*": the file is called
+          # <name>--<version>.<tag>.bottle.<rebuild>.tar.gz.
+          bottle=$(ls ./"${DISPATCH_REBOTTLE_FORMULA}"--*.bottle*.tar.gz)
+
+          brew uninstall --formula --force --ignore-dependencies "${DISPATCH_REBOTTLE_FORMULA}"
+          # "brew uninstall" autoremoves the dependencies it just orphaned, so
+          # put them back before pouring, as test-bot does.
+          brew install --only-dependencies "$bottle"
+          brew install "$bottle"
+          brew linkage --test "${DISPATCH_REBOTTLE_FORMULA}"
+          brew test --verbose "${DISPATCH_REBOTTLE_FORMULA}"
+
+      # "brew test-bot" exits 0 when it skips a formula -- a green build step
+      # does not mean a bottle exists.  Fail here rather than letting the
+      # upload job run "brew pr-upload" against an empty directory.
+      - name: Check that a bottle was actually built
+        working-directory: ${{ env.BOTTLES_DIR }}
+        env:
+          MATRIX_RUNNER: ${{ matrix.runner }}
+        run: |
+          if ! compgen -G "*.bottle.json" > /dev/null
+          then
+            echo "::error ::No bottle was produced for ${DISPATCH_REBOTTLE_FORMULA} on ${MATRIX_RUNNER}."
+            exit 1
+          fi
 
       - name: Post-build steps
         if: always()

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           script: |
             const macOSRunners = {
-              "14": "macos-14-large",
               "14-arm64": "macos-14",
               "15": "macos-15-intel",
               "15-arm64": "macos-15",

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -221,12 +221,9 @@ jobs:
 
   upload:
     permissions:
-      issues: write # for Homebrew/actions/post-comment
       contents: write # for Homebrew/actions/git-try-push
       packages: write # for brew pr-upload
-      pull-requests: write # for gh pr
-      attestations: write # for actions/attest
-      id-token: write # for actions/attest
+      pull-requests: write # for Homebrew/actions/create-pull-request
     runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
@@ -254,21 +251,11 @@ jobs:
           path: ${{ env.BOTTLES_DIR }}
           merge-multiple: true
 
-      - name: Setup git
+      - name: Configure Git user
         id: git-user-config
         uses: Homebrew/actions/git-user-config@main
         with:
           username: ${{ (github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot' }}
-
-      - name: Set up commit signing
-        uses: Homebrew/actions/setup-commit-signing@main
-        with:
-          signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
-
-      - name: Generate build provenance
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
 
       - name: Checkout branch for bottle commit
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
@@ -277,31 +264,32 @@ jobs:
       - name: Upload bottles to GitHub Packages
         id: upload
         env:
-          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_CORE_PATH: ${{steps.set-up-homebrew.outputs.repository-path}}
         working-directory: ${{ env.BOTTLES_DIR }}
         run: |
-          brew pr-upload --verbose --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/macaulay2/tap" --debug
+          brew pr-upload --verbose --debug --root-url="https://ghcr.io/v2/macaulay2/tap"
           echo "title=$(git -C "$HOMEBREW_CORE_PATH" log -1 --format='%s' "$BOTTLE_BRANCH")" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(git -C "$HOMEBREW_CORE_PATH" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@main
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ github.token }}
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           branch: ${{env.BOTTLE_BRANCH}}
-        env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
 
+      # Opening a PR with GITHUB_TOKEN needs the organisation's "Allow GitHub
+      # Actions to create and approve pull requests" setting, which is off by
+      # default and needs an org admin.  The branch has already been pushed by
+      # this point, so if PR creation is refused just carry on -- the summary
+      # below links straight to the compare view.
       - name: Open PR with bottle commit
         id: create-pr
+        continue-on-error: true
         uses: Homebrew/actions/create-pull-request@main
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{ github.token }}
           base: ${{github.ref}}
           head: ${{env.BOTTLE_BRANCH}}
           title: ${{steps.upload.outputs.title}}
@@ -311,67 +299,33 @@ jobs:
             -----
 
             ${{env.DISPATCH_REBOTTLE_REASON}}
-          labels: CI-published-bottle-commits
           reviewers: ${{github.actor}}
 
-      - name: Enable automerge
-        env:
-          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          NODE_ID: ${{steps.create-pr.outputs.node_id}}
-          SHA: ${{steps.upload.outputs.head_sha}}
-          MUTATION: |-
-            mutation ($input: EnablePullRequestAutoMergeInput!) {
-              enablePullRequestAutoMerge(input: $input) {
-                clientMutationId
-              }
-            }
+      # Deliberately success(), not always(): the text below asserts that the
+      # bottles reached ghcr, which is only true once "brew pr-upload" and the
+      # push have both succeeded.  A refused pull request does not skip this --
+      # that step is continue-on-error, so it leaves the job successful.
+      - name: Summarise
+        if: success()
         run: |
-          gh api graphql \
-            --field "input[pullRequestId]=$NODE_ID" \
-            --field "input[expectedHeadOid]=$SHA" \
-            --raw-field query="$MUTATION"
-
-      - name: Approve PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{steps.create-pr.outputs.number}}
-        run: |
-          gh api \
-            --method POST \
-            --header "Accept: application/vnd.github+json" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
-            --field "event=APPROVE"
-
-      - name: Wait until PR is merged
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.create-pr.outputs.number }}
-        run: |
-          # Hold the `concurrency` lock for up to another 10 minutes while the PR has not yet been merged.
-          sleep 300
-
-          attempt=0
-          max_attempts=5
-          sleep_time=10
-
-          while (( attempt < max_attempts ))
-          do
-            if jq --exit-status .merged_at
-            then
-              break
-            fi < <( # We could use `gh pr view`, but that uses 2 API calls.
-              gh api \
-                --header "Accept: application/vnd.github+json" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "/repos/$GITHUB_REPOSITORY/pulls/$PR"
-            )
-
-            sleep "$sleep_time"
-
-            sleep_time=$(( sleep_time * 2 ))
-            attempt=$(( attempt + 1 ))
-          done
+          {
+            echo "### Rebottled \`${DISPATCH_REBOTTLE_FORMULA}\`"
+            echo
+            echo "The bottles are **already on ghcr** -- \`brew pr-upload\` pushed them"
+            echo "before this branch existed.  Merging is what makes the formula reference them."
+            echo
+            echo "- Branch: \`${BOTTLE_BRANCH}\`"
+            echo "- Review and merge: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${BOTTLE_BRANCH}?expand=1"
+            echo
+            echo "A rebottle rebuilds every currently-bottled tag together, so expect the"
+            echo "whole \`bottle do\` block to be rewritten with a bumped \`rebuild\` -- unlike"
+            echo "\`dispatch-build-bottle\`, which adds a single \`sha256\` line.  Every tag that"
+            echo "was there before should still be there; this job only runs when every"
+            echo "runner succeeded."
+            echo
+            echo "Do **not** label it \`pr-pull\`: \`publish.yml\` runs \`brew pr-pull\` against"
+            echo "this pull request's own workflow artifacts, which are not the bottles above."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   comment:
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-14
-          - macos-14-large
           - macos-15
           - macos-15-intel
           - macos-26


### PR DESCRIPTION
Two pieces of CI cleanup.

### Drop `macos-14-large`

It is a billed larger runner, so the job has failed to schedule on every run and has never produced a bottle. Nothing is lost by removing it: no formula has a bare `sonoma:` tag, which is the only thing that runner could have built. GitHub's macOS 14 images are unsupported after 2026-11-02 ([actions/runner-images#13518](https://github.com/actions/runner-images/issues/13518)) in any case.

### Bring `dispatch-rebottle.yml` up to date

It never received three fixes that `dispatch-build-bottle.yml` got:

| | commit |
|---|---|
| No `--root-url` | 093adaf |
| No Intel workaround, and no check that a bottle was built | bc1659b |
| An upload job wired to homebrew-core secrets we do not have | d4ce446 |

The Intel gap is not theoretical. Twenty of our twenty-one formulae carry a `sequoia:` bottle, so `determine-rebottle-runners` does emit a `15-x86_64` runner and this workflow does land on `macos-15-intel` — where `test-bot` skips the formula for want of x86_64 sequoia dependencies and exits 0 having built nothing.

Unlike `dispatch-build-bottle` there is no `--keep-old`, matching the `test-bot` call: a rebottle rebuilds every currently bottled tag together, so the hand-rolled bottle must land on the same new rebuild number as the ones `test-bot` produces.

### Testing

Trial run on a fork with `upload: false`: [d-torrance/homebrew-tap run 31294267526](https://github.com/d-torrance/homebrew-tap/actions/runs/31294267526). All five bottle jobs green.

The gates route correctly in both directions — on `macos-15-intel` the `test-bot` step is skipped and the hand-rolled one runs; on `macos-14` it is the other way round. `cohomcalg` is at `rebuild 2`, and all five runners independently produced rebuild 3:

```
macos-14         cohomcalg--0.32_1.arm64_sonoma.bottle.3.tar.gz   (test-bot)
macos-15         cohomcalg--0.32_1.arm64_sequoia.bottle.3.tar.gz  (test-bot)
macos-26         cohomcalg--0.32_1.arm64_tahoe.bottle.3.tar.gz    (test-bot)
ubuntu-latest    cohomcalg--0.32_1.x86_64_linux.bottle.3.tar.gz   (test-bot)
macos-15-intel   cohomcalg--0.32_1.sequoia.bottle.3.tar.gz        (hand-rolled)
```

The `upload` job was skipped in that run, so it is not covered directly. It is however byte-identical to the one in `dispatch-build-bottle.yml` apart from the PR body, the summary text, `--debug`, and the deliberate absence of `--keep-old` — and that job has run to completion repeatedly, most recently through tonight's `sequoia:` backfill.

`actionlint` is clean at every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)